### PR TITLE
Internal: create `GitHub Action` to publish extension on tag creation

### DIFF
--- a/.github/workflows/publish-extension-from-tag.yml
+++ b/.github/workflows/publish-extension-from-tag.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Publishing a new release of the extension to Visual Studio Marketplace
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 21
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
# What?
- Publish a new version of this extension to the `VSCode` marketplace whenever a new tag is created.