### PR TITLE
Feature: add pull request, bug issue and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: 🐛 Bug Report
+about: Report a bug to help us improve
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## 🐞 Description
+_A clear and concise description of what the bug is._
+
+## 🤔 Expected Behavior
+_A clear and concise description of what you expected to happen._
+
+## 🖥️ System Info
+- _VS Code Version:_
+- _Extension Version:_

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: 🚀 Feature Request
+about: Suggest an new keybinding or feature
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## 💡 Description
+_A clear and concise description of what you want to happen._
+
+## 🎯 Additional
+_Is there an equivalent keybinding for `Xcode` and/or other context(s) you can include to describe the feature request_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+# Pull Request
+
+## 🚀 What does this PR do?
+_A short description of what your PR changes_
+
+## ✅ Checklist
+- _[ ] I have added new shortcut to the `README.md`_
+
+## 📸 Screencast (optional)
+_Add screen recording to help visualize the change_


### PR DESCRIPTION
# Why?
- To have one common template for pull requests
- To have a standard template for bug and feature requests

# What?
- Add `PULL_REQUEST_TEMPLATE.md` to `.github` folder
- Create `ISSUE_TEMPLATE` folder, create `bug_issue.md` and `feature_request.md`