### PR TITLE
Feature: add support for `Windows` and `Linux`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,45 +16,45 @@ This extension adds your favorite `Xcode` keyboard shortcuts to Visual Studio Co
 
 ##
 
-| Shortcut           | Description                                                    | Command                                            |
-|---------------|----------------------------------------------------------------|----------------------------------------------------|
-| `cmd+e`         | Add selection to next find match                               | `editor.action.addSelectionToNextFindMatch`          |
-| `cmd+shift+j`   | Show active file in explorer                                   | `workbench.files.action.showActiveFileInExplorer`     |
-| `cmd+ctrl+up`   | Switch between header and source file                          | `C_Cpp.SwitchHeaderSource`                           |
-| `shift+cmd+]`   | Move to next editor                                            | `workbench.action.nextEditor`                       |
-| `shift+cmd+[`   | Move to previous editor                                        | `workbench.action.previousEditor`                    |
-| `cmd+shift+y`   | Toggle panel visibility                                        | `workbench.action.togglePanel`                       |
-| `cmd+shift+o`   | Quick open files or commands                                   | `workbench.action.quickOpen`                         |
-| `ctrl+cmd+left` | Navigate back                                                  | `workbench.action.navigateBack`                      |
-| `ctrl+cmd+right`| Navigate forward                                               | `workbench.action.navigateForward`                   |
-| `cmd+1`         | Open Explorer view                                             | `workbench.view.explorer`                            |
-| `cmd+2`         | Open Search view                                               | `workbench.view.search`                              |
-| `cmd+3`        | Open Source Control view                                       | `workbench.view.scm`                                 |
-| `cmd+4`         | Open Debug view                                                | `workbench.view.debug`                               |
-| `cmd+5`         | Open Extensions view                                           | `workbench.view.extensions`                          |
-| `cmd+r`         | Start debug (when not in debug mode)                           | `workbench.action.debug.start`                       |
-| `cmd+r`         | Restart debug (when in debug mode)                             | `workbench.action.debug.restart`                     |
-| `cmd+.`         | Stop debug (when in debug mode)                                | `workbench.action.debug.stop`                        |
-| `cmd+b`         | Run build task                                                 | `workbench.action.tasks.build`                       |
-| `cmd+u`         | Run test task                                                  | `workbench.action.tasks.test`                        |
-| `cmd+0`         | Toggle sidebar visibility                                      | `workbench.action.toggleSidebarVisibility`           |
-| `ctrl+right`    | Move cursor word part right (when text input has focus)         | `cursorWordPartRight`                                |
-| `shift+ctrl+right`| Select word part right (when text input has focus)             | `cursorWordPartRightSelect`                          |
-| `ctrl+left`     | Move cursor word part start left (when text input has focus)    | `cursorWordPartStartLeft`                            |
-| `shift+ctrl+left`| Select word part start left (when text input has focus)         | `cursorWordPartStartLeftSelect`                      |
-| `ctrl+backspace`| Delete word part left (when text input has focus and editor is not readonly) | `deleteWordPartLeft`                                 |
-| `shift+ctrl+backspace`| Delete word part right (when text input has focus and editor is not readonly) | `deleteWordPartRight`                          |
-| `alt+cmd+left`  | Fold code                                                      | `editor.fold`                                        |
-| `alt+cmd+right` | Unfold code                                                    | `editor.unfold`                                      |
-| `alt+cmd+[`     | Move lines up                                                  | `editor.action.moveLinesUpAction`                    |
-| `alt+cmd+]`     | Move lines down                                                | `editor.action.moveLinesDownAction`                  |
-| `alt+up`        | Move cursor to start of line (when text input has focus)        | `cursorHome`                                         |
-| `alt+down`      | Move cursor to end of line (when text input has focus)          | `cursorEnd`                                          |
-| `ctrl+cmd+e`    | Change all occurrences (when editor has focus and is not readonly) | `editor.action.changeAll`                            |
-| `enter`         | Accept selected suggestion (when suggestion widget is visible and editor has focus) | `acceptSelectedSuggestion`               |
-| `ctrl+shift+up` | Insert cursor above (when editor has focus)                     | `editor.action.insertCursorAbove`                    |
-| `ctrl+shift+down`| Insert cursor below (when editor has focus)                     | `editor.action.insertCursorBelow`                    |
-| `cmd+l`         | Go to specific line (when text input has focus)                 | `workbench.action.gotoLine`                          |
-| `cmd+d`         | Duplicate selection (when editor has focus)                     | `editor.action.duplicateSelection`                   |
-| `ctrl+i`        | Reindent selected lines (when editor has focus and support for the language)                 | `editor.action.reindentselectedlines`                |
-| `ctrl+cmd+j`    | Reveal definition (when editor has definition provider and focus)| `editor.action.revealDefinition`                     |
+| Shortcut             | Mac             | Win              | Linux            | Command                                             | Description                                                                 |
+|----------------------|-----------------|------------------|------------------|-----------------------------------------------------|-----------------------------------------------------------------------------|
+| `cmd+e`              | `cmd+e`         | `ctrl+e`         | `ctrl+e`         | `editor.action.addSelectionToNextFindMatch`         | Add selection to next find match                                            |
+| `cmd+shift+j`        | `cmd+shift+j`   | `ctrl+shift+j`   | `ctrl+shift+j`   | `workbench.files.action.showActiveFileInExplorer`   | Show active file in explorer                                                |
+| `cmd+ctrl+up`        | `cmd+ctrl+up`   | `ctrl+win+up`    | `ctrl+super+up`  | `C_Cpp.SwitchHeaderSource`                         | Switch between header and source file                                       |
+| `shift+cmd+]`        | `shift+cmd+]`   | `shift+ctrl+]`   | `shift+ctrl+]`   | `workbench.action.nextEditor`                      | Move to next editor                                                         |
+| `shift+cmd+[`        | `shift+cmd+[`   | `shift+ctrl+[`   | `shift+ctrl+[`   | `workbench.action.previousEditor`                  | Move to previous editor                                                     |
+| `cmd+shift+y`        | `cmd+shift+y`   | `ctrl+shift+y`   | `ctrl+shift+y`   | `workbench.action.togglePanel`                     | Toggle panel visibility                                                     |
+| `cmd+shift+o`        | `cmd+shift+o`   | `ctrl+shift+o`   | `ctrl+shift+o`   | `workbench.action.quickOpen`                       | Quick open files or commands                                                |
+| `cmd+ctrl+left`      | `cmd+ctrl+left` | `ctrl+win+left`  | `ctrl+super+left`| `workbench.action.navigateBack`                    | Navigate back                                                               |
+| `cmd+ctrl+right`     | `cmd+ctrl+right`| `win+ctrl+right` | `super+ctrl+right`| `workbench.action.navigateForward`                 | Navigate forward                                                            |
+| `cmd+1`              | `cmd+1`         | `ctrl+1`         | `ctrl+1`         | `workbench.view.explorer`                          | Open Explorer view                                                          |
+| `cmd+2`              | `cmd+2`         | `ctrl+2`         | `ctrl+2`         | `workbench.view.search`                            | Open Search view                                                            |
+| `cmd+3`              | `cmd+3`         | `ctrl+3`         | `ctrl+3`         | `workbench.view.scm`                               | Open Source Control view                                                    |
+| `cmd+4`              | `cmd+4`         | `ctrl+4`         | `ctrl+4`         | `workbench.view.debug`                             | Open Debug view                                                             |
+| `cmd+5`              | `cmd+5`         | `ctrl+5`         | `ctrl+5`         | `workbench.view.extensions`                        | Open Extensions view                                                        |
+| `cmd+r`              | `cmd+r`         | `ctrl+r`         | `ctrl+r`         | `workbench.action.debug.start`                     | Start debug (when not in debug mode)                                        |
+| `cmd+r`              | `cmd+r`         | `ctrl+r`         | `ctrl+r`         | `workbench.action.debug.restart`                   | Restart debug (when in debug mode)                                          |
+| `cmd+.`              | `cmd+.`         | `ctrl+.`         | `ctrl+.`         | `workbench.action.debug.stop`                      | Stop debug (when in debug mode)                                             |
+| `cmd+b`              | `cmd+b`         |                  |                  | `workbench.action.tasks.build`                     | Run build task                                                              |
+| `cmd+u`              | `cmd+u`         |                  |                  | `workbench.action.tasks.test`                      | Run test task                                                               |
+| `cmd+0`              | `cmd+0`         |                  |                  | `workbench.action.toggleSidebarVisibility`         | Toggle sidebar visibility                                                   |
+| `ctrl+right`         | `ctrl+right`    | `win+right`      | `super+right`    | `cursorWordPartRight`                              | Move cursor word part right (when text input has focus)                     |
+| `shift+ctrl+right`   | `shift+ctrl+right`| `shift+win+right`| `shift+super+right`| `cursorWordPartRightSelect`                    | Select word part right (when text input has focus)                          |
+| `ctrl+left`          | `ctrl+left`     | `win+left`       | `super+left`     | `cursorWordPartStartLeft`                          | Move cursor word part start left (when text input has focus)                |
+| `shift+ctrl+left`    | `shift+ctrl+left`| `shift+win+left` | `shift+super+left`| `cursorWordPartStartLeftSelect`                  | Select word part start left (when text input has focus)                     |
+| `ctrl+backspace`     | `ctrl+backspace`| `win+backspace`  | `super+backspace`| `deleteWordPartLeft`                               | Delete word part left (when text input has focus and editor is not readonly)|
+| `shift+ctrl+backspace`| `shift+ctrl+backspace`| `shift+win+backspace`| `shift+super+backspace`| `deleteWordPartRight`                  | Delete word part right (when text input has focus and editor is not readonly)|
+| `alt+cmd+left`       |                 |                  |                  | `editor.fold`                                      | Fold code                                                                   |
+| `alt+cmd+right`      |                 |                  |                  | `editor.unfold`                                    | Unfold code                                                                 |
+| `alt+cmd+[`          |                 |                  |                  | `editor.action.moveLinesUpAction`                  | Move lines up                                                               |
+| `alt+cmd+]`          |                 |                  |                  | `editor.action.moveLinesDownAction`                | Move lines down                                                             |
+| `alt+up`             | `alt+up`        | `alt+up`         | `alt+up`         | `cursorHome`                                       | Move cursor to start of line (when text input has focus)                    |
+| `alt+down`           | `alt+down`      | `alt+down`       | `alt+down`       | `cursorEnd`                                        | Move cursor to end of line (when text input has focus)                      |
+| `ctrl+cmd+e`         | `ctrl+cmd+e`    | `win+ctrl+e`     | `super+ctrl+e`   | `editor.action.changeAll`                          | Change all occurrences (when editor has focus and is not readonly)          |
+| `enter`              | `enter`         | `enter`          | `enter`          | `acceptSelectedSuggestion`                         | Accept selected suggestion (when suggestion widget is visible and editor has focus)|
+| `ctrl+shift+up`      | `ctrl+shift+up` | `win+shift+up`   | `super+shift+up` | `editor.action.insertCursorAbove`                  | Insert cursor above (when editor has focus)                                 |
+| `ctrl+shift+down`    | `ctrl+shift+down`| `win+shift+down` | `super+shift+down`| `editor.action.insertCursorBelow`                | Insert cursor below (when editor has focus)                                 |
+| `cmd+l`              | `cmd+l`         | `ctrl+l`         | `ctrl+l`         | `workbench.action.gotoLine`                        | Go to specific line (when text input has focus)                             |
+| `ctrl+i`             | `ctrl+i`        | `ctrl+i`         | `ctrl+i`         | `editor.action.reindentselectedlines`              | Reindent selected lines (when editor has focus and support for the language)|
+| `cmd+d`              | `cmd+d`         | `ctrl+d`         | `ctrl+d`         | `editor.action.duplicateSelection`                 | Duplicate selection (when editor has focus)                                 |
+| `cmd+\``            | `cmd+\``        | `ctrl+\``        | `ctrl+\``        | `workbench.action.terminal.newWithCwd`             | Open new terminal at file directory                                         |

--- a/package.json
+++ b/package.json
@@ -35,79 +35,132 @@
     "keybindings": [
       {
         "key": "cmd+e",
-        "command": "editor.action.addSelectionToNextFindMatch"
+        "command": "editor.action.addSelectionToNextFindMatch",
+        "mac": "cmd+e",
+        "win": "ctrl+e",
+        "linux": "ctrl+e"
       },
       {
         "key": "cmd+shift+j",
-        "command": "workbench.files.action.showActiveFileInExplorer"
+        "command": "workbench.files.action.showActiveFileInExplorer",
+        "mac": "cmd+shift+j",
+        "win": "ctrl+shift+j",
+        "linux": "ctrl+shift+j"
       },
       {
         "key": "cmd+ctrl+up",
         "command": "C_Cpp.SwitchHeaderSource",
-        "when": "editorTextFocus && editorLangId == 'cpp' || editorLangId == 'c'"
+        "mac": "cmd+ctrl+up",
+        "win": "ctrl+win+up",
+        "linux": "ctrl+super+up"
       },
       {
         "key": "shift+cmd+]",
         "command": "workbench.action.nextEditor",
-        "when": "editorTextFocus"
+        "mac": "shift+cmd+]",
+        "win": "shift+ctrl+]",
+        "linux": "shift+ctrl+]"
       },
       {
         "key": "shift+cmd+[",
         "command": "workbench.action.previousEditor",
-        "when": "editorTextFocus"
+        "mac": "shift+cmd+[",
+        "win": "shift+ctrl+[",
+        "linux": "shift+ctrl+["
       },
       {
         "key": "cmd+shift+y",
         "command": "workbench.action.togglePanel",
-        "when": "editorTextFocus"
+        "mac": "cmd+shift+y",
+        "win": "ctrl+shift+y",
+        "linux": "ctrl+shift+y"
       },
       {
         "key": "cmd+shift+o",
         "command": "workbench.action.quickOpen",
-        "when": "editorTextFocus"
+        "mac": "cmd+shift+o",
+        "win": "ctrl+shift+o",
+        "linux": "ctrl+shift+o"
       },
       {
-        "key": "ctrl+cmd+left",
-        "command": "workbench.action.navigateBack"
+        "key": "cmd+ctrl+left",
+        "command": "workbench.action.navigateBack",
+        "mac": "cmd+ctrl+left",
+        "win": "ctrl+win+left",
+        "linux": "ctrl+super+left"
       },
       {
-        "key": "ctrl+cmd+right",
-        "command": "workbench.action.navigateForward"
+        "key": "cmd+ctrl+left",
+        "command": "workbench.action.navigateBack",
+        "mac": "cmd+ctrl+left",
+        "win": "win+ctrl+left",
+        "linux": "super+ctrl+left"
+      },
+      {
+        "key": "cmd+ctrl+right",
+        "command": "workbench.action.navigateForward",
+        "mac": "cmd+ctrl+right",
+        "win": "win+ctrl+right",
+        "linux": "super+ctrl+right"
       },
       {
         "key": "cmd+1",
-        "command": "workbench.view.explorer"
+        "command": "workbench.view.explorer",
+        "mac": "cmd+1",
+        "win": "ctrl+1",
+        "linux": "ctrl+1"
       },
       {
         "key": "cmd+2",
-        "command": "workbench.view.search"
+        "command": "workbench.view.search",
+        "mac": "cmd+2",
+        "win": "ctrl+2",
+        "linux": "ctrl+2"
       },
       {
         "key": "cmd+3",
-        "command": "workbench.view.scm"
+        "command": "workbench.view.scm",
+        "mac": "cmd+3",
+        "win": "ctrl+3",
+        "linux": "ctrl+3"
       },
       {
         "key": "cmd+4",
-        "command": "workbench.view.debug"
+        "command": "workbench.view.debug",
+        "mac": "cmd+4",
+        "win": "ctrl+4",
+        "linux": "ctrl+4"
       },
       {
         "key": "cmd+5",
-        "command": "workbench.view.extensions"
+        "command": "workbench.view.extensions",
+        "mac": "cmd+5",
+        "win": "ctrl+5",
+        "linux": "ctrl+5"
       },
       {
         "key": "cmd+r",
         "command": "workbench.action.debug.start",
-        "when": "!inDebugMode"
+        "when": "!inDebugMode",
+        "mac": "cmd+r",
+        "win": "ctrl+r",
+        "linux": "ctrl+r"
       },
       {
         "key": "cmd+r",
         "command": "workbench.action.debug.restart",
-        "when": "inDebugMode"
+        "when": "inDebugMode",
+        "mac": "cmd+r",
+        "win": "ctrl+r",
+        "linux": "ctrl+r"
       },
       {
         "key": "cmd+.",
         "command": "workbench.action.debug.stop",
-        "when": "inDebugMode"
+        "when": "inDebugMode",
+        "mac": "cmd+.",
+        "win": "ctrl+.",
+        "linux": "ctrl+."
       },
       {
         "key": "cmd+b",
@@ -127,32 +180,50 @@
       {
         "key": "ctrl+right",
         "command": "cursorWordPartRight",
-        "when": "textInputFocus"
+        "when": "textInputFocus",
+        "mac": "ctrl+right",
+        "win": "win+right",
+        "linux": "super+right"
       },
       {
         "key": "shift+ctrl+right",
         "command": "cursorWordPartRightSelect",
-        "when": "textInputFocus"
+        "when": "textInputFocus",
+        "mac": "shift+ctrl+right",
+        "win": "shift+win+right",
+        "linux": "shift+super+right"
       },
       {
         "key": "ctrl+left",
         "command": "cursorWordPartStartLeft",
-        "when": "textInputFocus"
+        "when": "textInputFocus",
+        "mac": "ctrl+left",
+        "win": "win+left",
+        "linux": "super+left"
       },
       {
         "key": "shift+ctrl+left",
         "command": "cursorWordPartStartLeftSelect",
-        "when": "textInputFocus"
+        "when": "textInputFocus",
+        "mac": "shift+ctrl+left",
+        "win": "shift+win+left",
+        "linux": "shift+super+left"
       },
       {
         "key": "ctrl+backspace",
         "command": "deleteWordPartLeft",
-        "when": "textInputFocus && !editorReadonly"
+        "when": "textInputFocus && !editorReadonly",
+        "mac": "ctrl+backspace",
+        "win": "win+backspace",
+        "linux": "super+backspace"
       },
       {
         "key": "shift+ctrl+backspace",
         "command": "deleteWordPartRight",
-        "when": "textInputFocus && !editorReadonly"
+        "when": "textInputFocus && !editorReadonly",
+        "mac": "shift+ctrl+backspace",
+        "win": "shift+win+backspace",
+        "linux": "shift+super+backspace"
       },
       {
         "key": "alt+cmd+left",
@@ -177,52 +248,84 @@
       {
         "key": "alt+up",
         "command": "cursorHome",
-        "when": "textInputFocus"
+        "when": "textInputFocus",
+        "mac": "alt+up",
+        "win": "alt+up",
+        "linux": "alt+up"
       },
       {
         "key": "alt+down",
         "command": "cursorEnd",
-        "when": "textInputFocus"
+        "when": "textInputFocus",
+        "mac": "alt+down",
+        "win": "alt+down",
+        "linux": "alt+down"
       },
       {
         "key": "ctrl+cmd+e",
         "command": "editor.action.changeAll",
-        "when": "editorTextFocus && !editorReadonly"
+        "when": "editorTextFocus && !editorReadonly",
+        "mac": "ctrl+cmd+e",
+        "win": "win+ctrl+e",
+        "linux": "super+ctrl+e"
       },
       {
         "key": "enter",
         "command": "acceptSelectedSuggestion",
-        "when": "editorTextFocus && suggestWidgetVisible"
+        "when": "editorTextFocus && suggestWidgetVisible",
+        "mac": "enter",
+        "win": "enter",
+        "linux": "enter"
       },
       {
         "key": "ctrl+shift+up",
         "command": "editor.action.insertCursorAbove",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus",
+        "mac": "ctrl+shift+up",
+        "win": "win+shift+up",
+        "linux": "super+shift+up"
       },
       {
         "key": "ctrl+shift+down",
         "command": "editor.action.insertCursorBelow",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus",
+        "mac": "ctrl+shift+down",
+        "win": "win+shift+down",
+        "linux": "super+shift+down"
       },
       {
         "key": "cmd+l",
         "command": "workbench.action.gotoLine",
-        "when": "textInputFocus"
-      },
-      {
-        "key": "cmd+d",
-        "command": "editor.action.duplicateSelection",
-        "when": "editorTextFocus"
+        "when": "textInputFocus",
+        "mac": "cmd+l",
+        "win": "ctrl+l",
+        "linux": "ctrl+l"
       },
       {
         "key": "ctrl+i",
         "command": "editor.action.reindentselectedlines",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus",
+        "mac": "ctrl+i",
+        "win": "ctrl+i",
+        "linux": "ctrl+i"
       },
       {
-        "key": "ctrl+cmd+j",
-        "command": "editor.action.revealDefinition",
-        "when": "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
+        "key": "cmd+d",
+        "command": "editor.action.duplicateSelection",
+        "when": "editorTextFocus",
+        "mac": "cmd+d",
+        "win": "ctrl+d",
+        "linux": "ctrl+d"
+      },
+      {
+        "key": "cmd+`",
+        "command": "workbench.action.terminal.newWithCwd",
+        "mac": "cmd+`",
+        "win": "ctrl+`",
+        "linux": "ctrl+`",
+        "args": {
+          "cwd": "${fileDirname}"
+        }
       }
     ]
   },


### PR DESCRIPTION
## 🚀 What does this PR do?
- Add support for the bindings that are available on `MacOS` to `Windows` and `Linux`; by specifying the platform (`mac`, `win` or `linux`) and equivalent keybinding in `package.json`.
- Update the `README` to list the bindings for each respective platform
- Swap the `command` and `description` columns so it's easier to read what each keybinding does.

## ✅ Checklist
- [x] I have added new shortcuts to the `README.md`
- [x] I have listed shortcut for each platform in the `README.md`