### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-extension-from-tag.yml
+++ b/.github/workflows/publish-extension-from-tag.yml
@@ -4,6 +4,8 @@ on:
       - "*"
 
 name: Publishing a new release to Visual Studio Marketplace
+permissions:
+  contents: read
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/robinsalehjan/vscode-xcode-shortcuts/security/code-scanning/1](https://github.com/robinsalehjan/vscode-xcode-shortcuts/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly indicate the minimal permission required. Since this workflow publishes to the VS Marketplace (it does not push new commits or manipulate pull requests), and only uses `actions/checkout`, `actions/setup-node`, and the publisher action (with a marketplace token secret), it likely only needs `contents: read` (to checkout the code and package it for the publish step). The appropriate place to add the `permissions` key is at the workflow root, so its restriction applies to all jobs, unless job-specific overrides are needed. Insert this block right after the `name:` entry near the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
