### PR TITLE
docs: remove retired Visual Studio Marketplace badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/robinsalehjan/vscode-xcode-shortcuts/publish-extension-from-tag.yml)
 ![Tests](https://img.shields.io/github/actions/workflow/status/robinsalehjan/vscode-xcode-shortcuts/test.yml?label=tests)
 ![GitHub License](https://img.shields.io/github/license/robinsalehjan/vscode-xcode-shortcuts)
-![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/robinsalehjan.xcode-vscode-shortcuts)
 ![GitHub Release](https://img.shields.io/github/v/release/robinsalehjan/vscode-xcode-shortcuts)
 
 This extension adds your favorite `Xcode` keyboard shortcuts to Visual Studio Code!


### PR DESCRIPTION
## Summary
- Removes the retired `visual-studio-marketplace/v` shields.io badge from the README.

## Test plan
- [x] No code changes; README renders without broken badge.