### PR TITLE
ci: publish via vsce/ovsx CLIs instead of publish-vscode-extension action

### DIFF
--- a/.github/workflows/publish-extension-from-tag.yml
+++ b/.github/workflows/publish-extension-from-tag.yml
@@ -22,13 +22,16 @@ jobs:
           node-version: 22
           cache: 'npm'
       - run: npm install
+      # vsce/ovsx are pinned here rather than declared as devDependencies so the
+      # test matrix does not install them. Bump these two versions by hand.
+      - name: Package extension
+        run: npx --yes @vscode/vsce@3.9.2 package --out extension.vsix
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v2
-        with:
-          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          registryUrl: https://marketplace.visualstudio.com
+        env:
+          VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+        run: npx --yes @vscode/vsce@3.9.2 publish --packagePath extension.vsix
       - name: Publish to Open VSX Registry
         if: env.OPEN_VSX_TOKEN != ''
-        uses: HaaLeo/publish-vscode-extension@v2
-        with:
-          pat: ${{ env.OPEN_VSX_TOKEN }}
+        env:
+          OVSX_PAT: ${{ env.OPEN_VSX_TOKEN }}
+        run: npx --yes ovsx@1.1.1 publish extension.vsix


### PR DESCRIPTION
## Why

Every release logs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `HaaLeo/publish-vscode-extension@v2`

The pin can't simply be bumped. `v2.0.0` (Feb 2025) is the newest release of that action, its `action.yml` declares `using: 'node20'`, and there is no Node 24 release or open issue tracking one upstream.

## What

Drop the third-party action and call the official CLIs directly. They run on the runner's Node 22 from `setup-node`, which removes the last node20 action from the workflow — the only two remaining, `actions/checkout@v7` and `actions/setup-node@v7`, both declare `using: node24`.

- `@vscode/vsce@3.9.2` — packages, then publishes to the Visual Studio Marketplace
- `ovsx@1.1.1` — publishes to Open VSX

Two incidental improvements:

- **Packaged once, published twice.** The old setup invoked the action twice, packaging separately for each registry. Now a single `extension.vsix` goes to both, so the registries are guaranteed to receive identical bytes.
- **Tokens moved from action inputs to env vars** (`VSCE_PAT` / `OVSX_PAT`, both read natively by the CLIs), keeping them out of process argv.

`vsce` is the same tool the old action wrapped internally, which is why the artifact is unchanged.

## Verification

This workflow only fires on tag push, so CI cannot exercise it on this PR. Checks run locally against a clean checkout of `HEAD`:

- `vsce package` using the exact command in this diff produced **24 files, 77.79 KB** — byte-identical to the artifact the action produced for the 1.5.3 release
- `vsce publish --packagePath` with a dummy token resolved `robinsalehjan.xcode-vscode-shortcuts v1.5.3` from the vsix and failed only at authentication (`TF400813`), confirming argument handling and `VSCE_PAT` pickup
- `ovsx publish` likewise parsed the vsix path, picked up `OVSX_PAT`, and reached the Open VSX server
- Workflow YAML parses; structural tests pass

Both repo secrets are present and confirmed working — the 1.5.3 release published successfully to both registries.

## Note for reviewers

`vsce` and `ovsx` are pinned inline rather than added to `devDependencies`, so the test matrix doesn't install them and dependabot PR volume doesn't grow. The tradeoff is that these two versions must be bumped by hand; there's a comment in the workflow saying so. Happy to move them to `devDependencies` instead if you'd rather dependabot track them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)