### PR TITLE
chore: add emoji prefixes to workflow names

### DIFF
--- a/.github/workflows/publish-extension-from-tag.yml
+++ b/.github/workflows/publish-extension-from-tag.yml
@@ -3,7 +3,7 @@ on:
     tags:
       - "[0-9]*.[0-9]*.[0-9]*"
 
-name: Publishing a new release to Visual Studio Marketplace
+name: 🚀 Publishing a new release to Visual Studio Marketplace
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
 
-name: Reusable test suite
+name: ♻️ Reusable test suite
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
 
-name: Tests
+name: 🧪 Tests
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Adds an emoji to the front of each GitHub Actions workflow name so they're easier to scan in the Actions sidebar.

- `test.yml` → 🧪 Tests
- `reusable-tests.yml` → ♻️ Reusable test suite
- `publish-extension-from-tag.yml` → 🚀 Publishing a new release to Visual Studio Marketplace

Name-only change; no workflow logic touched.